### PR TITLE
Loosen react peer dep requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">= 16.8.0"
   }
 }


### PR DESCRIPTION
Rect 17.x works fine afaict, and I hate getting unnecessary warnings like:
```
WARN  react-use-uuid@2.0.0 requires a peer of react@^16.8.0 but version 17.0.2 was installed.
```